### PR TITLE
FIX: Swaps order of implode() arguments for PHP 7.4, 8.0+ compat

### DIFF
--- a/remote-media-resolver.php
+++ b/remote-media-resolver.php
@@ -47,7 +47,7 @@ class RemoteMediaResolver {
         }
 
         $remote_host_arr = get_option( 'rmr_remote_host', [] );
-        $remote_host = implode( $remote_host_arr, '.' );
+        $remote_host = implode( '.', $remote_host_arr );
         ?>
         <div class="wrap">
             <h1>Remote Media Resolver Settings</h1>
@@ -80,7 +80,7 @@ class RemoteMediaResolver {
         $remote_host_arr = get_option( 'rmr_remote_host', false );
         if ( !$remote_host_arr ) return;
 
-        $remote_host = implode( $remote_host_arr, '.' );
+        $remote_host = implode( '.', $remote_host_arr );
         $request = $_SERVER['REQUEST_URI'];
         $path = $this->get_path( $request );
         $base_path = $this->get_upload_path();


### PR DESCRIPTION
Passing glue string after array is deprecated in PHP 7.4 and removed in PHP 8.0+

Thanks for making this plugin! It's a real help for local development.